### PR TITLE
chore: update Go version to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.2**.

### Changes
- Dockerfile: golang:1.26 → golang:1.26.2

_Automated PR by update-go-version.sh_