### PR TITLE
chore: update Go version to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module instawatch
 
-go 1.26.2
+go 1.26.3


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.3**.

### Changes
- go.mod: go 1.26.2 → go 1.26.3
- Dockerfile: golang:1.26.2 → golang:1.26.3

_Automated PR by update-go-version.sh_