### PR TITLE
chore: update Go version to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module instawatch
 
-go 1.26.3
+go 1.26.4


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.4**.

### Changes
- go.mod: go 1.26.3 → go 1.26.4
- Dockerfile: golang:1.26.3 → golang:1.26.4

_Automated PR by update-go-version.sh_