### PR TITLE
Evict cached videos by last access instead of download time

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -8,27 +8,64 @@ import (
 )
 
 type videoInfo struct {
-	Path        string
-	Title       string
-	Description string
-	OriginalURL string
+	Path         string
+	Title        string
+	Description  string
+	OriginalURL  string
+	LastAccessed time.Time
 }
+
+const (
+	videoRetention  = 24 * time.Hour
+	janitorInterval = time.Hour
+)
 
 var (
 	cache   = make(map[string]videoInfo)
 	cacheMu sync.RWMutex
 )
 
-func scheduleVideoDeletion(urlHash, videoPath string, delay time.Duration) {
-	time.AfterFunc(delay, func() {
-		cacheMu.Lock()
-		delete(cache, urlHash)
-		cacheMu.Unlock()
+// touchVideo refreshes the last-accessed time of a cached video so that files
+// people are still watching are kept alive instead of being re-downloaded.
+func touchVideo(urlHash string) {
+	cacheMu.Lock()
+	if info, ok := cache[urlHash]; ok {
+		info.LastAccessed = time.Now()
+		cache[urlHash] = info
+	}
+	cacheMu.Unlock()
+}
 
+// startCacheJanitor periodically deletes videos that have not been accessed
+// within the retention period.
+func startCacheJanitor(interval, retention time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			cleanupExpiredVideos(retention)
+		}
+	}()
+}
+
+func cleanupExpiredVideos(retention time.Duration) {
+	now := time.Now()
+
+	cacheMu.Lock()
+	expiredPaths := make(map[string]string)
+	for urlHash, info := range cache {
+		if now.Sub(info.LastAccessed) >= retention {
+			expiredPaths[urlHash] = info.Path
+			delete(cache, urlHash)
+		}
+	}
+	cacheMu.Unlock()
+
+	for _, videoPath := range expiredPaths {
 		if err := os.Remove(videoPath); err != nil {
 			log.Printf("Failed to delete video %s: %v", videoPath, err)
 		} else {
-			log.Printf("Deleted video after %v: %s", delay, videoPath)
+			log.Printf("Deleted video not accessed for %v: %s", retention, videoPath)
 		}
-	})
+	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -7,48 +7,75 @@ import (
 	"time"
 )
 
-func TestScheduleVideoDeletion(t *testing.T) {
+func TestCleanupExpiredVideos(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	videoPath := filepath.Join(tmpDir, "test_video.mp4")
-	err := os.WriteFile(videoPath, []byte("dummy content"), 0644)
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
+	freshPath := filepath.Join(tmpDir, "fresh.mp4")
+	stalePath := filepath.Join(tmpDir, "stale.mp4")
+	for _, p := range []string{freshPath, stalePath} {
+		if err := os.WriteFile(p, []byte("dummy content"), 0644); err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
 	}
 
-	urlHash := "test_hash"
+	retention := time.Hour
 
 	cacheMu.Lock()
-	cache[urlHash] = videoInfo{Path: videoPath, Title: "Test Video"}
+	cache["fresh_hash"] = videoInfo{Path: freshPath, LastAccessed: time.Now()}
+	cache["stale_hash"] = videoInfo{Path: stalePath, LastAccessed: time.Now().Add(-2 * retention)}
 	cacheMu.Unlock()
 
-	if _, err := os.Stat(videoPath); os.IsNotExist(err) {
-		t.Fatalf("Temp file %s should exist before deletion", videoPath)
+	t.Cleanup(func() {
+		cacheMu.Lock()
+		delete(cache, "fresh_hash")
+		delete(cache, "stale_hash")
+		cacheMu.Unlock()
+	})
+
+	cleanupExpiredVideos(retention)
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("Stale video %s should have been deleted", stalePath)
+	}
+	cacheMu.RLock()
+	_, staleExists := cache["stale_hash"]
+	cacheMu.RUnlock()
+	if staleExists {
+		t.Fatalf("Stale cache entry should have been removed")
 	}
 
-	delay := 2 * time.Second
-	scheduleVideoDeletion(urlHash, videoPath, delay)
-
-	time.Sleep(1 * time.Second)
-	if _, err := os.Stat(videoPath); os.IsNotExist(err) {
-		t.Fatalf("Temp file %s was deleted too early (before %v)", videoPath, delay)
+	if _, err := os.Stat(freshPath); err != nil {
+		t.Fatalf("Fresh video %s should not have been deleted: %v", freshPath, err)
 	}
+	cacheMu.RLock()
+	_, freshExists := cache["fresh_hash"]
+	cacheMu.RUnlock()
+	if !freshExists {
+		t.Fatalf("Fresh cache entry should have been kept")
+	}
+}
+
+func TestTouchVideo(t *testing.T) {
+	urlHash := "touch_hash"
+	old := time.Now().Add(-time.Hour)
+
+	cacheMu.Lock()
+	cache[urlHash] = videoInfo{Path: "/tmp/whatever.mp4", LastAccessed: old}
+	cacheMu.Unlock()
+
+	t.Cleanup(func() {
+		cacheMu.Lock()
+		delete(cache, urlHash)
+		cacheMu.Unlock()
+	})
+
+	touchVideo(urlHash)
 
 	cacheMu.RLock()
-	if _, exists := cache[urlHash]; !exists {
-		t.Fatalf("Cache entry for %s was deleted too early", urlHash)
-	}
+	updated := cache[urlHash].LastAccessed
 	cacheMu.RUnlock()
 
-	time.Sleep(1500 * time.Millisecond)
-
-	if _, err := os.Stat(videoPath); !os.IsNotExist(err) {
-		t.Fatalf("Temp file %s was not deleted after %v", videoPath, delay)
+	if !updated.After(old) {
+		t.Fatalf("touchVideo did not refresh LastAccessed: got %v, want after %v", updated, old)
 	}
-
-	cacheMu.RLock()
-	if _, exists := cache[urlHash]; exists {
-		t.Fatalf("Cache entry for %s was not deleted after %v", urlHash, delay)
-	}
-	cacheMu.RUnlock()
 }

--- a/handlers.go
+++ b/handlers.go
@@ -60,6 +60,7 @@ func handleRoot(w http.ResponseWriter, r *http.Request, tmpDir string) {
 
 	if exists {
 		if _, err := os.Stat(cachedVal.Path); err == nil {
+			touchVideo(urlHash)
 			servePlayer(w, urlHash, cachedVal)
 			return
 		}
@@ -77,15 +78,14 @@ func handleRoot(w http.ResponseWriter, r *http.Request, tmpDir string) {
 
 	cacheMu.Lock()
 	val := videoInfo{
-		Path:        videoPath,
-		Title:       title,
-		Description: description,
-		OriginalURL: rawURL,
+		Path:         videoPath,
+		Title:        title,
+		Description:  description,
+		OriginalURL:  rawURL,
+		LastAccessed: time.Now(),
 	}
 	cache[urlHash] = val
 	cacheMu.Unlock()
-
-	scheduleVideoDeletion(urlHash, videoPath, 24*time.Hour)
 
 	servePlayer(w, urlHash, val)
 }
@@ -132,6 +132,7 @@ func handleVideo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	touchVideo(urlHash)
 	http.ServeFile(w, r, cachedVal.Path)
 }
 
@@ -151,6 +152,7 @@ func handleDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	touchVideo(urlHash)
 	filename := filepath.Base(cachedVal.Path)
 	disposition := mime.FormatMediaType("attachment", map[string]string{"filename": filename})
 	w.Header().Set("Content-Disposition", disposition)

--- a/main.go
+++ b/main.go
@@ -110,6 +110,8 @@ func main() {
 		}
 	}
 
+	startCacheJanitor(janitorInterval, videoRetention)
+
 	mux := http.NewServeMux()
 	mux.Handle("GET /static/", http.FileServer(http.FS(staticFiles)))
 	mux.HandleFunc("GET /sw.js", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Closes #26. Cache eviction was tied to download time: a one-shot timer deleted each video 24h after download, even if people were still watching — forcing a needless re-download.

This switches to last-access-based retention:

- `videoInfo` gains a `LastAccessed` timestamp.
- `touchVideo` refreshes it (mutex-guarded) on every cache hit in `handleRoot`, `handleVideo`, and `handleDownload`, so actively watched videos stay alive.
- A background janitor (`startCacheJanitor`, runs hourly) deletes only videos idle longer than the 24h retention window, replacing the per-video `time.AfterFunc`.

## Concurrency

Touches happen under the existing `cacheMu` lock, so multiple simultaneous viewers are handled correctly. On Linux an in-flight `http.ServeFile` keeps streaming via the open inode even if the file is removed mid-request.

## Tests

`TestCleanupExpiredVideos` (fresh kept, stale deleted) and `TestTouchVideo` replace the old timer test. `go build`, `go test`, `go vet`, and `golangci-lint` all pass.