### PR TITLE
fix: pin curl_cffi back to 0.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 yt-dlp==2026.7.4
-curl_cffi==0.16.0
+curl_cffi==0.15.0


### PR DESCRIPTION
## Summary
- Urgent hotfix: `main` is currently broken in production. #33 bumped `curl_cffi` to `0.16.0`, which yt-dlp's impersonate backend does not support (`yt_dlp/networking/_curlcffi.py` caps supported versions at `0.5.10` or `0.10.x`–`0.15.x`). Every download currently fails with `Impersonate target "chrome" is not available.`
- Reverts `requirements.txt` to `curl_cffi==0.15.0`, the last known-good version.
- #34 adds a CI check that would have caught this before merge; landing this hotfix first restores downloads, #34 prevents recurrence.

## Test plan
- [x] Reproduced the failure locally: `curl_cffi==0.16.0` + `yt-dlp==2026.7.4` → `--list-impersonate-targets` shows all targets `(unavailable)`
- [x] Confirmed `curl_cffi==0.15.0` restores working impersonate targets
- [x] CI green on this PR