### PR TITLE
Add What's Up Docker for automatic image updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,18 @@ services:
     environment:
       - INSTAGRAM_SESSION_ID=${INSTAGRAM_SESSION_ID}
       - FACEBOOK_SESSION_ID=${FACEBOOK_SESSION_ID}
+    labels:
+      - wud.watch=true
+
+  wud:
+    image: getwud/wud
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WUD_WATCHER_LOCAL_WATCHBYDEFAULT=false
+      - WUD_TRIGGER_DOCKER_LOCAL_AUTO=true
+      - WUD_TRIGGER_DOCKER_LOCAL_PRUNE=true
 
 volumes:
   instawatch-data:


### PR DESCRIPTION
## Summary
- Watchtower is unmaintained; replace it with [What's Up Docker](https://github.com/getwud/wud) for automatic updates of the `instawatch` image.
- `wud` is scoped to only the `instawatch` container (`WUD_WATCHER_LOCAL_WATCHBYDEFAULT=false` + `wud.watch=true` label), not every container on the host.
- Auto-update and post-update image pruning are enabled (`WUD_TRIGGER_DOCKER_LOCAL_AUTO`, `WUD_TRIGGER_DOCKER_LOCAL_PRUNE`).
- Default check interval is hourly (WUD's built-in default, `0 * * * *`).

## Test plan
- [x] `docker compose config -q` validates the compose file
- [x] `docker compose up -d` on a host with the image published to ghcr.io, confirm `wud` starts and only tracks `instawatch`