### PR TITLE
Switch to Chainguard base images, harden and shrink the final image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,9 @@ jobs:
             exit 1
           fi
 
+      - name: End-to-end test (download a real Instagram reel)
+        run: ./scripts/e2e-smoke-test.sh instawatch:test-amd64
+
   docker-arm64:
     name: Build Docker image (arm64)
     runs-on: ubuntu-24.04-arm
@@ -68,3 +71,6 @@ jobs:
             echo "::error::no curl_cffi-backed impersonate targets found"
             exit 1
           fi
+
+      - name: End-to-end test (download a real Instagram reel)
+        run: ./scripts/e2e-smoke-test.sh instawatch:test-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,13 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o instawatch .
 
-# ffmpeg has no runtime-only Chainguard image on the free tier, and the wolfi apk
-# package pulls in ~190MB of encoder libraries (x264/x265/aom/svt-av1/opus/...)
-# that this app never uses: downloader.go only ever stream-copies ("-c copy"),
-# it never transcodes. So build a minimal ffmpeg from source instead, with no
-# --enable-lib* flags, which keeps every native demuxer/muxer/decoder (plenty
-# for remuxing whatever Instagram/Facebook serve) but drops all those optional
-# encoder dependencies. --disable-network is safe (ffmpeg only ever touches
-# local temp files here) and shrinks the attack surface further.
+# Built from source with no --enable-lib* flags: downloader.go only ever
+# stream-copies, so the external encoder libs the wolfi apk package pulls in
+# (x264, x265, aom, srt, ssh, zeromq, ...) aren't needed.
 FROM cgr.dev/chainguard/wolfi-base AS ffmpeg
 RUN apk add --no-cache build-base nasm pkgconf wget xz zlib-dev
 
 ARG FFMPEG_VERSION=7.1.1
-# Self-pinned from the official https://ffmpeg.org/releases/ download (no
-# published sha256sum file upstream, only a GPG .asc signature) to catch
-# corruption/tampering on rebuilds.
 ARG FFMPEG_SHA256=733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
 
 RUN wget -q -O /tmp/ffmpeg.tar.xz "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,62 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o instawatch .
 
-FROM alpine:3.24
+# ffmpeg has no runtime-only Chainguard image on the free tier, and the wolfi apk
+# package pulls in ~190MB of encoder libraries (x264/x265/aom/svt-av1/opus/...)
+# that this app never uses: downloader.go only ever stream-copies ("-c copy"),
+# it never transcodes. So build a minimal ffmpeg from source instead, with no
+# --enable-lib* flags, which keeps every native demuxer/muxer/decoder (plenty
+# for remuxing whatever Instagram/Facebook serve) but drops all those optional
+# encoder dependencies. --disable-network is safe (ffmpeg only ever touches
+# local temp files here) and shrinks the attack surface further.
+FROM cgr.dev/chainguard/wolfi-base AS ffmpeg
+RUN apk add --no-cache build-base nasm pkgconf wget xz zlib-dev
 
+ARG FFMPEG_VERSION=7.1.1
+# Self-pinned from the official https://ffmpeg.org/releases/ download (no
+# published sha256sum file upstream, only a GPG .asc signature) to catch
+# corruption/tampering on rebuilds.
+ARG FFMPEG_SHA256=733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
+
+RUN wget -q -O /tmp/ffmpeg.tar.xz "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
+    && echo "${FFMPEG_SHA256}  /tmp/ffmpeg.tar.xz" | sha256sum -c - \
+    && mkdir -p /tmp/src \
+    && tar -xf /tmp/ffmpeg.tar.xz -C /tmp/src --strip-components=1
+
+WORKDIR /tmp/src
+RUN ./configure \
+      --prefix=/opt/ffmpeg \
+      --disable-static --enable-shared \
+      --disable-doc --disable-debug \
+      --disable-avdevice \
+      --disable-network \
+      --disable-ffplay \
+      --disable-postproc \
+    && make -j"$(nproc)" \
+    && make install \
+    && mkdir -p /data-empty
+
+FROM cgr.dev/chainguard/python:latest-dev AS pydeps
+USER root
+WORKDIR /app
 COPY requirements.txt .
-RUN apk add --no-cache python3 py3-pip ffmpeg \
-    && pip3 install --break-system-packages -r requirements.txt
+RUN python -m venv /venv \
+    && /venv/bin/pip install --no-cache-dir -r requirements.txt \
+    && /venv/bin/python -m pip uninstall -y pip setuptools
+
+FROM cgr.dev/chainguard/python:latest
+
+COPY --from=ffmpeg /opt/ffmpeg/lib/*.so* /usr/lib/
+COPY --from=ffmpeg /opt/ffmpeg/bin/ffmpeg /opt/ffmpeg/bin/ffprobe /usr/bin/
+
+COPY --from=pydeps /venv /venv
+ENV PATH="/venv/bin:${PATH}"
 
 COPY --from=builder /app/instawatch /usr/local/bin/instawatch
+COPY --from=ffmpeg --chown=nonroot:nonroot --chmod=700 /data-empty /data
 
-RUN adduser -D -u 1000 instawatch \
-    && mkdir -p /data \
-    && chown instawatch:instawatch /data \
-    && chmod 700 /data
 ENV DATA_DIR=/data
 VOLUME ["/data"]
 
-USER instawatch
 EXPOSE 8080
-CMD ["instawatch"]
+ENTRYPOINT ["instawatch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apk add --no-cache build-base nasm pkgconf wget xz zlib-dev
 ARG FFMPEG_VERSION=7.1.1
 ARG FFMPEG_SHA256=733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
 
-RUN wget -q -O /tmp/ffmpeg.tar.xz "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
+RUN wget -q --tries=5 --timeout=30 --retry-connrefused -O /tmp/ffmpeg.tar.xz \
+      "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
     && echo "${FFMPEG_SHA256}  /tmp/ffmpeg.tar.xz" | sha256sum -c - \
     && mkdir -p /tmp/src \
     && tar -xf /tmp/ffmpeg.tar.xz -C /tmp/src --strip-components=1

--- a/scripts/e2e-smoke-test.sh
+++ b/scripts/e2e-smoke-test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Starts the given image, downloads a real public Instagram reel through it,
+# and checks that a valid mp4 comes back. Used by .github/workflows/docker.yml
+# after each arch's image is built.
+set -euo pipefail
+
+IMAGE="${1:?usage: e2e-smoke-test.sh <image>}"
+PORT="${2:-18080}"
+CONTAINER_NAME="instawatch-e2e-$$"
+TEST_URL="https://www.instagram.com/reel/DZdHKycNrsb/"
+
+cleanup() {
+  echo "::group::container logs"
+  docker logs "$CONTAINER_NAME" 2>&1 || true
+  echo "::endgroup::"
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run -d --name "$CONTAINER_NAME" -p "${PORT}:8080" "$IMAGE"
+
+echo "Waiting for InstaWatch to come up..."
+ready=""
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:${PORT}/" >/dev/null; then
+    echo "Ready after ${i}s"
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [ -z "$ready" ]; then
+  echo "::error::service did not become ready within 30s"
+  exit 1
+fi
+
+echo "Requesting player page for a real Instagram reel..."
+page="$(mktemp)"
+status=$(curl -sfL -o "$page" -w '%{http_code}' --max-time 90 "http://localhost:${PORT}/${TEST_URL}")
+if [ "$status" != "200" ]; then
+  echo "::error::player page returned HTTP $status"
+  cat "$page"
+  exit 1
+fi
+
+hash=$(grep -oE '/video/[0-9a-f]{32}' "$page" | head -1 | sed 's#/video/##')
+if [ -z "$hash" ]; then
+  echo "::error::could not find a video hash in the player page"
+  cat "$page"
+  exit 1
+fi
+
+echo "Downloading the served video (hash=${hash})..."
+video="$(mktemp --suffix=.mp4)"
+video_status=$(curl -sf -o "$video" -w '%{http_code}' --max-time 60 "http://localhost:${PORT}/video/${hash}")
+if [ "$video_status" != "200" ]; then
+  echo "::error::video endpoint returned HTTP $video_status"
+  exit 1
+fi
+
+size=$(stat -c%s "$video")
+echo "Downloaded ${size} bytes"
+if [ "$size" -lt 100000 ]; then
+  echo "::error::downloaded video is suspiciously small (${size} bytes)"
+  exit 1
+fi
+
+if ! file "$video" | grep -qi 'ISO Media\|MP4'; then
+  echo "::error::downloaded file does not look like an mp4"
+  file "$video"
+  exit 1
+fi
+
+echo "End-to-end check passed: real Instagram reel downloaded and served correctly."


### PR DESCRIPTION
## Summary
- Final image is now built on `cgr.dev/chainguard/python` instead of `alpine` + `apk`-installed python/pip: no shell, no `apk`, no `pip` in the runtime image (pip is uninstalled from the venv right after `requirements.txt` is installed), runs as `nonroot` by default. Alpine's musl also meant curl_cffi could only use musllinux wheels; Chainguard is glibc-based, matching the more common manylinux wheels.
- `ffmpeg` has no free-tier Chainguard image, and the Wolfi `apk` package pulls in ~190MB of encoder/protocol libs (x264, x265, aom, svt-av1, srt, ssh, zeromq, ...) this app never uses — `downloader.go` only ever stream-copies (`-c copy -movflags faststart`), never transcodes. Built ffmpeg from source instead with no `--enable-lib*` flags: keeps every native demuxer/muxer/decoder (h264, aac, vp9, av1, opus, vorbis, ...) needed for remuxing whatever Instagram/Facebook serve, drops the unused external encoders, and `--disable-network` narrows ffmpeg's own attack surface since it only ever touches local temp files here. Source tarball is checksum-pinned (upstream only ships a GPG `.asc`, no plain sha256 file).
- Net effect: smaller and more locked-down image than the original alpine one.
  - alpine (before): 294MB, had a shell + apk + pip
  - Chainguard + full apk ffmpeg (intermediate): 377MB, no shell/apk/pip
  - Chainguard + source-built minimal ffmpeg (this PR): 221MB, no shell/apk/pip

## Test plan
- [x] `docker build` succeeds
- [x] No `/bin/sh`, no `apk`, no `pip` reachable in the final image
- [x] `ffmpeg`/`ffprobe` run; the exact `-c copy -movflags faststart` remux from `downloader.go` produces a valid faststart mp4 (checked with `ffprobe`)
- [x] `yt-dlp --list-impersonate-targets` reports `curl_cffi`-backed targets — the same check the `docker.yml` CI workflow gates on
- [x] Container boots, logs yt-dlp/curl_cffi versions, and serves HTTP 200
- [x] `docker-compose.yml`'s named `/data` volume still gets correct ownership/perms for the new `nonroot` (65532) UID