### PR TITLE
Fix release Docker build: fetch ffmpeg source from GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,16 @@ FROM cgr.dev/chainguard/wolfi-base AS ffmpeg
 RUN apk add --no-cache build-base nasm pkgconf wget xz zlib-dev
 
 ARG FFMPEG_VERSION=7.1.1
-ARG FFMPEG_SHA256=733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1
+# ffmpeg.org's own download server intermittently refuses/times out connections
+# from GitHub Actions runners, which broke a release build. GitHub's mirror of
+# the FFmpeg repo shares GitHub's infra and has been far more reliable in CI.
+ARG FFMPEG_SHA256=f117507dc501f2a6c11f9241d8d0c3213846cfad91764361af37befd6b6c523d
 
-RUN wget -q --tries=5 --timeout=30 --retry-connrefused -O /tmp/ffmpeg.tar.xz \
-      "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" \
-    && echo "${FFMPEG_SHA256}  /tmp/ffmpeg.tar.xz" | sha256sum -c - \
+RUN wget -q --tries=5 --timeout=30 --retry-connrefused -O /tmp/ffmpeg.tar.gz \
+      "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n${FFMPEG_VERSION}.tar.gz" \
+    && echo "${FFMPEG_SHA256}  /tmp/ffmpeg.tar.gz" | sha256sum -c - \
     && mkdir -p /tmp/src \
-    && tar -xf /tmp/ffmpeg.tar.xz -C /tmp/src --strip-components=1
+    && tar -xf /tmp/ffmpeg.tar.gz -C /tmp/src --strip-components=1
 
 WORKDIR /tmp/src
 RUN ./configure \


### PR DESCRIPTION
## Summary
The `v1.7.0` release build failed (https://github.com/jadolg/instawatch/actions/runs/31253388449/job/93093077566): the amd64 leg of the ffmpeg-source `wget` step got a hard network failure against `ffmpeg.org` even with the retries added in #37, while the arm64 leg (same job, same runner, same egress IP) succeeded seconds later — `ffmpeg.org` appears to intermittently refuse/rate-limit connections from GitHub Actions IPs.

Switched to downloading the same `n7.1.1` source from GitHub's official FFmpeg mirror (`github.com/FFmpeg/FFmpeg`) instead of `ffmpeg.org/releases`. Same content, checksum re-pinned against the new source, but on GitHub's own infra which every other step in this pipeline already depends on.

## Test plan
- [x] `docker build --no-cache` succeeds end to end from a clean cache
- [x] `scripts/e2e-smoke-test.sh` passes against the resulting image (real Instagram reel download + serve)

## Next step
Once merged, `v1.7.0`'s tag/commit won't include this fix (tags are immutable once released) — main will need a new release (e.g. `v1.7.1`) to get a working Docker image published.