### PR TITLE
Build release images natively per-arch instead of QEMU

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           images: |
             ${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.authors=Jorge Alberto Díaz Orozco (Akiel)
+            org.opencontainers.image.vendor=jadolg
+            org.opencontainers.image.documentation=https://github.com/jadolg/instawatch#readme
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,29 @@ on:
   release:
     types: [ created ]
 
+env:
+  IMAGE_NAME: ghcr.io/jadolg/instawatch
+
 jobs:
-  docker:
-    name: Build and push Docker image
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v7
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
       - name: Login to Docker registry
         uses: docker/login-action@v4
         with:
@@ -26,21 +40,71 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: |
-            ghcr.io/jadolg/instawatch
+            ${{ env.IMAGE_NAME }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest and push
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Login to Docker registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            VERSION=${{ github.ref_name }}
-            COMMIT=${{ github.sha }}
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary
- arm64 release builds took ~1h40m because ffmpeg was compiled from source under QEMU emulation on an amd64 runner — the identical arm64 build already runs natively on `ubuntu-24.04-arm` in `docker.yml` and finishes in ~5m.
- `release.yml` now splits into per-platform build jobs (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`), each pushing by digest, then a `merge` job combines the digests into the final multi-arch manifest with `docker buildx imagetools create`.
- Dockerfile/ffmpeg build itself is unchanged (still the minimal non-GPL source build) — only the runner topology changed.

## Test plan
- [ ] Cut a release and confirm the `build` matrix + `merge` job succeed and the pushed manifest is multi-arch (`docker buildx imagetools inspect ghcr.io/jadolg/instawatch:<tag>`)
- [ ] Confirm arm64 leg no longer runs under QEMU (should finish in single-digit minutes, not ~1h40m)