### PR TITLE
chore: update Go version to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module instawatch
 
-go 1.26.5
+go 1.26.6


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.6**.

### Changes
- go.mod: go 1.26.5 → go 1.26.6
- Dockerfile: golang:1.26.5 → golang:1.26.6

_Automated PR by update-go-version.sh_